### PR TITLE
✨[FEAT] 로그인 API 연동을 위한 providerId, accessToken 반환

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -7,7 +7,7 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.32/17d46b3e205515e1e8efd3ee4d57ce8018914163/lombok-1.18.32.jar" />
         </processorPath>
-        <module name="com.example.majorLink.main" />
+        <module name="majorLink.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -9,6 +9,8 @@
           <option value="refresh-token" />
           <option value="X-Auth-Token" />
           <option value="refresh-Token" />
+          <option value="providerId" />
+          <option value="accessToken" />
         </set>
       </option>
     </inspection_tool>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/com.example.majorLink.main.iml" filepath="$PROJECT_DIR$/.idea/modules/com.example.majorLink.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/majorLink.main.iml" filepath="$PROJECT_DIR$/.idea/modules/majorLink.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/majorLink_server.iml" filepath="$PROJECT_DIR$/.idea/majorLink_server.iml" />
     </modules>
   </component>

--- a/majorLink/src/main/java/com/example/majorLink/global/auth/AuthController.java
+++ b/majorLink/src/main/java/com/example/majorLink/global/auth/AuthController.java
@@ -25,22 +25,13 @@ public class AuthController {
     }
 
     @GetMapping("/result/new-user")
-    public void returnLoginResult(HttpServletResponse response,
-                                  @RequestParam(value = "username") String username,
-                                  @RequestParam(value = "email") String email,
-                                  @RequestParam(value = "profileImg") String profileImg,
-                                  @RequestParam(value = "phone") String phone,
-                                  @RequestParam(value = "gender", required = false) String gender) throws IOException {
-        FirstLoginResponse firstLogInResponse = FirstLoginResponse.builder()
-                .username(username)
-                .email(email)
-                .phone(phone)
-                .profileImg(profileImg)
-                .gender(gender)
-                .build();
+    public void returnFirstLoginResult(HttpServletResponse response,
+                                  @RequestParam(name = "providerId") String providerId,
+                                  @RequestParam(name = "accessToken") String accessToken)
+                                  throws IOException {
 
-//        response.setHeader("temp-token", tempToken);
-        response.getWriter().write(objectMapper.writeValueAsString(firstLogInResponse));
+        response.setHeader("providerId", providerId);
+        response.setHeader("accessToken", accessToken);
     }
 
 //    @PostMapping("/reissue-token")

--- a/majorLink/src/main/java/com/example/majorLink/global/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/majorLink/src/main/java/com/example/majorLink/global/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -48,12 +48,8 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
 
             OAuthAttributes attributes = oAuth2User.getOAuthAttributes();
             String uri = UriComponentsBuilder.fromUriString(redirectUrl + "/new-user")
-//                    .queryParam("temp-token", String.valueOf(socialInfo.getTemporalToken()))
-                    .queryParam("username", attributes.getUsername())
-                    .queryParam("email", attributes.getEmail())
-                    .queryParam("profileImg", attributes.getProfileImg())
-                    .queryParam("phone", attributes.getPhone())
-                    .queryParam("gender", attributes.getGender())
+                    .queryParam("providerId", attributes.getId())
+                    .queryParam("accessToken", attributes.getAccessToken())
                     .toUriString();
 
             response.sendRedirect(uri);

--- a/majorLink/src/main/java/com/example/majorLink/global/oauth2/OAuthAttributes.java
+++ b/majorLink/src/main/java/com/example/majorLink/global/oauth2/OAuthAttributes.java
@@ -23,6 +23,11 @@ public class OAuthAttributes {
     private String profileImg;
     private Gender gender;
     private String phone;
+    private String accessToken;
+
+    public void updateAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
 
     public static OAuthAttributes of(SocialType provider, String userNameAttribute, Map<String, Object> attributes) {
         Map<String, Object> response = (Map<String, Object>) attributes.get(userNameAttribute);
@@ -36,18 +41,19 @@ public class OAuthAttributes {
 
     public static OAuthAttributes ofNaver(Map<String, Object> response) {
         OAuthAttributes oAuthAttributes = new OAuthAttributes();
-        oAuthAttributes.id = (String) response.get("id");
-        oAuthAttributes.email = (String) response.get("email");
-        oAuthAttributes.username = (String) response.get("name");
-        oAuthAttributes.phone = (String) response.get("phone");
-        oAuthAttributes.profileImg = (String) response.get("profile_image");
-        String gender = (String) response.get("gender");
-
-        if ("F".equals(gender)) {
-            oAuthAttributes.gender = Gender.FEMALE;
-        } else if ("M".equals(gender)) {
-            oAuthAttributes.gender = Gender.MALE;
-        }
+//        oAuthAttributes.id = (String) response.get("id");
+//        oAuthAttributes.email = (String) response.get("email");
+//        oAuthAttributes.username = (String) response.get("name");
+//        oAuthAttributes.phone = (String) response.get("phone");
+//        oAuthAttributes.profileImg = (String) response.get("profile_image");
+        oAuthAttributes.accessToken = (String) response.get("accessToken");
+//        String gender = (String) response.get("gender");
+//
+//        if ("F".equals(gender)) {
+//            oAuthAttributes.gender = Gender.FEMALE;
+//        } else if ("M".equals(gender)) {
+//            oAuthAttributes.gender = Gender.MALE;
+//        }
 
         return oAuthAttributes;
     }

--- a/majorLink/src/main/java/com/example/majorLink/global/oauth2/OAuthLoginService.java
+++ b/majorLink/src/main/java/com/example/majorLink/global/oauth2/OAuthLoginService.java
@@ -39,6 +39,7 @@ public class OAuthLoginService extends DefaultOAuth2UserService {
                 .getUserNameAttributeName();
 
         OAuthAttributes oAuthAttributes = OAuthAttributes.of(provider, userNameAttribute, oAuth2User.getAttributes());
+        oAuthAttributes.updateAccessToken(userRequest.getAccessToken().getTokenValue());
 
         log.info(oAuthAttributes.getId());
         log.info("***********************");

--- a/majorLink/src/main/resources/application.yml
+++ b/majorLink/src/main/resources/application.yml
@@ -45,8 +45,6 @@ spring:
       host: localhost
       port: 6379
       database: 1
-server:
-  port: 9000
 
 logging:
   level:

--- a/majorLink/src/main/resources/application.yml
+++ b/majorLink/src/main/resources/application.yml
@@ -46,6 +46,9 @@ spring:
       port: 6379
       database: 1
 
+server:
+  port: 8080
+
 logging:
   level:
     org:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #29

## 📌 개요
- ✨[FEAT] 로그인 API 연동을 위한 providerId, accessToken 반환 (#29)

## 🔁 변경 사항
- 프론트와의 API 연동을 위해 유저 DB에 저장되지 않은 유저가 처음으로 로그인을 할 경우 providerId와 accessToken 값이 헤더에 보이게 됩니다.

## 👀 기타 더 이야기해볼 점
- 보안 문제로 후에 providerId, accessToken 값이 헤더에서 사라질 수 있습니다.
- #13 이슈의 확장 PR입니다. 브랜치 혼란으로 브랜치와 이슈 번호가 다릅니다.
- 빠르게 처리해야하는 이슈로, 리뷰 없이 바로 머지합니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.