### PR TITLE
♻️ [REFACTOR] 수강신청 API와 알림 전송 API를 분리

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/majorLink.main.iml" filepath="$PROJECT_DIR$/.idea/modules/majorLink.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/majorLink.test.iml" filepath="$PROJECT_DIR$/.idea/modules/majorLink.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/majorLink_server.iml" filepath="$PROJECT_DIR$/.idea/majorLink_server.iml" />
     </modules>
   </component>

--- a/majorLink/src/main/java/com/example/majorLink/controller/NotificationController.java
+++ b/majorLink/src/main/java/com/example/majorLink/controller/NotificationController.java
@@ -36,6 +36,22 @@ public class NotificationController {
         return notificationService.subscribe(user, lastEventId);
     }
 
+    @PostMapping("/{lectureId}")
+    public ResponseEntity<?> sendNotification(@PathVariable(name = "lectureId") Long lectureId,
+                                              @AuthenticationPrincipal AuthUser authUser) {
+        User user = authUser.getUser();
+        String msg = user.getNickname() + " 님으로 부터 수업 신청이 왔습니다.";
+        notificationService.send(user, lectureId, msg);
+        return ResponseEntity.status(HttpStatus.OK)
+                .build();
+
+    }
+
+
+    // 수강 신청 시 튜터에게 알림 전달
+
+
+
     /**
      * 알림 전체 조회
      * [GET] /notification

--- a/majorLink/src/main/java/com/example/majorLink/domain/Notification.java
+++ b/majorLink/src/main/java/com/example/majorLink/domain/Notification.java
@@ -1,14 +1,9 @@
 package com.example.majorLink.domain;
 
-import com.example.majorLink.domain.enums.CheckStatus;
-import com.example.majorLink.domain.mapping.UserNotification;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter

--- a/majorLink/src/main/java/com/example/majorLink/service/LectureServiceImpl.java
+++ b/majorLink/src/main/java/com/example/majorLink/service/LectureServiceImpl.java
@@ -178,10 +178,6 @@ public class LectureServiceImpl implements LectureService {
 
         TuteeLecture savedTuteeLecture = tuteeLectureRepository.save(tuteeLecture);
 
-        // 수강 신청 시 튜터에게 알림 전달
-        String msg = user.getNickname() + " 님으로 부터 수업 신청이 왔습니다.";
-        notificationService.send(user, lecture, msg);
-
         return savedTuteeLecture;
 
     }

--- a/majorLink/src/main/java/com/example/majorLink/service/NotificationService.java
+++ b/majorLink/src/main/java/com/example/majorLink/service/NotificationService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface NotificationService {
     SseEmitter subscribe(User user, String lastEventId);
-    void send(User sender, Lecture lecture, String content);
+    void send(User sender, Long lectureId, String content);
 
     // 전체 알림 조회
     List<NotificationResponse> getNotificationList(User user);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #72

## 📌 개요
- ♻️ [REFACTOR] 수강신청 API와 알림 전송 API를 분리 (#72)

## 🔁 변경 사항
* 수강신청 API와 알림 전송 API를 분리 (/notification/{lectureId})

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.