### PR TITLE
♻️ [REFACTOR] sender와 receiver에 동일한 user 정보가 저장되던 오류 해결

### DIFF
--- a/majorLink/src/main/java/com/example/majorLink/domain/User.java
+++ b/majorLink/src/main/java/com/example/majorLink/domain/User.java
@@ -31,7 +31,7 @@ public class User extends BaseEntity{
 
     @Column(nullable = false, length = 20)
     private String nickname;
-    @Column(nullable = false, length = 8)
+    @Column(nullable = false, length = 10)
     private String birth;
 
     @Column(nullable = false)

--- a/majorLink/src/main/java/com/example/majorLink/service/NotificationServiceImpl.java
+++ b/majorLink/src/main/java/com/example/majorLink/service/NotificationServiceImpl.java
@@ -60,7 +60,7 @@ public class NotificationServiceImpl implements NotificationService {
         Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다."));
 
-        Notification notification = notificationRepository.save(createNotification(lecture.getUser(), lectureId, content));
+        Notification notification = notificationRepository.save(createNotification(sender, lectureId, content));
         UUID receiverId = lecture.getUser().getId();
 
         Map<String, SseEmitter> sseEmitters = emitterRepository.findAllEmitterStartWithByUserId(receiverId);       // 알림 받는 사람 아이디

--- a/majorLink/src/main/resources/application.yml
+++ b/majorLink/src/main/resources/application.yml
@@ -42,17 +42,18 @@ spring:
 
   data:
     redis:
-      host: ${REDIS_AWS_ENDPOINT}
+      host: localhost
       port: 6379
       database: 1
 
 server:
   port: 8080
   http2:
-    enabled: true
-  tomcat:
-    threads:
-      max: 200
+    enabled: false
+#  tomcat:
+#    threads:
+#      max: 200
+
 
 logging:
   level:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #94

## 📌 개요
- ♻️ [REFACTOR] sender와 receiver에 동일한 사람이 들어가는 오류 해결 (#94)

## 🔁 변경 사항
* sender에 receiver의 정보가 들어가는 오류가 있어 수정했습니다
   * sender에는 수강 신청을 한 튜티의 정보
   * receiver에는 강의를 생성한 튜터의 정보
   
## 📸 스크린샷
![image](https://github.com/user-attachments/assets/dcccabf2-e03d-41c4-b597-db3152162c05)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.